### PR TITLE
Fix floating indices for activity localization

### DIFF
--- a/src/processing.py
+++ b/src/processing.py
@@ -47,7 +47,8 @@ def activity_localization(sequence_class_prob, activity_threshold=.2):
     activities_idx = []
     scores = []
 
-    for s, e in zip(startings, endings):
+    for segment in zip(startings, endings):
+    	s, e = map(int, segment)
         activities_idx.append(activity_idx)
         scores.append(np.mean(sequence_class_prob[s:e,activity_idx]))
 


### PR DESCRIPTION
Indexes for ```sequence_class_prob``` are of float type with versions of numpy >=1.12. The PR attempts to fix the issue. 